### PR TITLE
update wallet for react native

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,48 +1,48 @@
 {
 	"name": "@cryptoeconomicslab/tezos-liteclient-cli",
-	"version": "0.0.6",
+	"version": "0.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@cryptoeconomicslab/coder": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/coder/-/coder-0.0.27.tgz",
-			"integrity": "sha512-Uf7FgeTKsCYK52yRqCv6WfYHJdEmMsE9fDpivLDQybpwR796l0VBroj7nvFiqgQUcZQ2LPa8Tzap+tOIAQA47w==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/coder/-/coder-0.0.34.tgz",
+			"integrity": "sha512-C9bReasdjkI9fVe3XpVG3s3arUZZPQClJiO4i7xDilaUemNAlZxl7t1LlyIOyYd3TbeMxIP+GC1gIkXVf7Bycw==",
 			"requires": {
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/context": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/context/-/context-0.0.27.tgz",
-			"integrity": "sha512-TByB9O9zpXqXqetuvaGNlBwaBr+/leo4uJRjGT4rRrq8ZNGJexQzL5g4u3Kns4tmh2rc36e3ldbpvT4V5ZHDFQ=="
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/context/-/context-0.0.34.tgz",
+			"integrity": "sha512-0l1V1zwMRtzLtrr4FgUqy+hCY0KBjyVdafP467+eltz/QqYQ4zmx8RYkwm1j+dF23NqAXNK3LYodoJ3PlOVgkw=="
 		},
 		"@cryptoeconomicslab/contract": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/contract/-/contract-0.0.27.tgz",
-			"integrity": "sha512-mRyKSeAeursDPKKHMLwvhbaAjEINomXZJ5QpJB9w9jFfl3a3+/6W5ILwjXUanpmNcDYNVqnLyHYWwzGX/fB/Vw==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/contract/-/contract-0.0.34.tgz",
+			"integrity": "sha512-wvdk/5YKjHzE+xwj/NukUZN4Bi93vbhPd+6zdiD+Yg8FU/cHaOpx79WhclapriJacmFoO0t2pbjUrrDivtBIfw==",
 			"requires": {
-				"@cryptoeconomicslab/coder": "^0.0.27",
-				"@cryptoeconomicslab/db": "^0.0.27",
-				"@cryptoeconomicslab/ovm": "^0.0.27"
+				"@cryptoeconomicslab/coder": "^0.0.34",
+				"@cryptoeconomicslab/db": "^0.0.34",
+				"@cryptoeconomicslab/ovm": "^0.0.34"
 			}
 		},
 		"@cryptoeconomicslab/db": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/db/-/db-0.0.27.tgz",
-			"integrity": "sha512-ZZjH44tMT1Krynr63NIL5NQ0pf1R6fC6Lytqf4MjsaGfbiUD2y15OWf4qw8rDFYPUwdIJNR2I5d4Pm2kN1p2ig==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/db/-/db-0.0.34.tgz",
+			"integrity": "sha512-H2t8VnmqaehOe7CjLWn5Dg5NDTuNSvGjHI9WNWt8onGMlbkkTwRieYYh5nf3Hhp1vK2sOmCUf6aHbyJg1fv4gw==",
 			"requires": {
-				"@cryptoeconomicslab/coder": "^0.0.27",
-				"@cryptoeconomicslab/context": "^0.0.27",
-				"@cryptoeconomicslab/utils": "^0.0.27",
+				"@cryptoeconomicslab/coder": "^0.0.34",
+				"@cryptoeconomicslab/context": "^0.0.34",
+				"@cryptoeconomicslab/utils": "^0.0.34",
 				"abstract-leveldown": "^6.2.2",
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/hash": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/hash/-/hash-0.0.27.tgz",
-			"integrity": "sha512-vl4pqbCjISn+Xqy5zRhdbFYW4cwlIWx3f9AiEwTZ6a9QEdQy7Ew0tvJtJ9ev8xmtCk4IoYjKQ4gOF8skP8p+uA==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/hash/-/hash-0.0.34.tgz",
+			"integrity": "sha512-5bLcLLSU8dI1uRw6jaRqCSs0D6E2itvfPQbtQ4qu5CDBSHSvEltiexCnZ7mPpfcPZ6nBoAMY4F2i/jNTUSXdtw==",
 			"requires": {
 				"ethers": "^4.0.43"
 			}
@@ -64,28 +64,28 @@
 			}
 		},
 		"@cryptoeconomicslab/merkle-tree": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/merkle-tree/-/merkle-tree-0.0.27.tgz",
-			"integrity": "sha512-Y8SkkIh962E0hezjB+RHAfAnWAtxxasn0Ywo/lZTTtEwalVpBZBYA6zbe5pzDvoL+nZ48oF4hKYnMxAlWBoiFg==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/merkle-tree/-/merkle-tree-0.0.34.tgz",
+			"integrity": "sha512-p1zNaF0RWpsDWNF3CLUNKBo+r99LvsZkQYlcmWHrTwCbXwrhl1cvqxm5kzoYgrxzIcDlSDWQuGDxdzPnS8DipQ==",
 			"requires": {
-				"@cryptoeconomicslab/hash": "^0.0.27",
-				"@cryptoeconomicslab/utils": "^0.0.27",
+				"@cryptoeconomicslab/hash": "^0.0.34",
+				"@cryptoeconomicslab/utils": "^0.0.34",
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/ovm": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/ovm/-/ovm-0.0.27.tgz",
-			"integrity": "sha512-mxrQFleLMh4N15+GyG8aO6bXg9RB3lRAHyQad+z9+kVSn3BWTvoXSzzT1I7DbS14r+3Gh/5PvTW+ZGP9Gb0F3A==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/ovm/-/ovm-0.0.34.tgz",
+			"integrity": "sha512-W91ld+ZlgY97swESNBQUDDc9wwZQOqRVGcpChG0iRhHVYYENokwS0Lohb9ZHrUAf3QIDP22Tqckj3yImtElaLg==",
 			"requires": {
-				"@cryptoeconomicslab/coder": "^0.0.27",
-				"@cryptoeconomicslab/db": "^0.0.27",
-				"@cryptoeconomicslab/hash": "^0.0.27",
+				"@cryptoeconomicslab/coder": "^0.0.34",
+				"@cryptoeconomicslab/db": "^0.0.34",
+				"@cryptoeconomicslab/hash": "^0.0.34",
 				"@cryptoeconomicslab/ovm-parser": "^0.2.5",
 				"@cryptoeconomicslab/ovm-transpiler": "^0.2.7",
-				"@cryptoeconomicslab/primitives": "^0.0.27",
-				"@cryptoeconomicslab/signature": "^0.0.27",
-				"@cryptoeconomicslab/utils": "^0.0.27",
+				"@cryptoeconomicslab/primitives": "^0.0.34",
+				"@cryptoeconomicslab/signature": "^0.0.34",
+				"@cryptoeconomicslab/utils": "^0.0.34",
 				"jsbi": "^3.1.1"
 			}
 		},
@@ -131,104 +131,67 @@
 			}
 		},
 		"@cryptoeconomicslab/plasma": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/plasma/-/plasma-0.0.27.tgz",
-			"integrity": "sha512-tUdmyCyNrw33VGVBpqk/mxoYIc4E/4wesNjTyrrgOT2hbFBUzqD2r3ctzBxA54R1E4GwYoOqyL8YteXVJwdaAg==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/plasma/-/plasma-0.0.34.tgz",
+			"integrity": "sha512-g3FOzTx7VVZNCY+ei9iWodnaghnPqkoJggcT7boTOs5ffB278gFxYPxbyx027Zj2SRQLTATQ83N6R/ybnwXWJQ==",
 			"requires": {
-				"@cryptoeconomicslab/db": "^0.0.27",
-				"@cryptoeconomicslab/hash": "^0.0.27",
-				"@cryptoeconomicslab/merkle-tree": "^0.0.27",
-				"@cryptoeconomicslab/ovm": "^0.0.27",
+				"@cryptoeconomicslab/db": "^0.0.34",
+				"@cryptoeconomicslab/hash": "^0.0.34",
+				"@cryptoeconomicslab/merkle-tree": "^0.0.34",
+				"@cryptoeconomicslab/ovm": "^0.0.34",
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/plasma-light-client": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/plasma-light-client/-/plasma-light-client-0.0.27.tgz",
-			"integrity": "sha512-j2KV9ESpATEiln5zixpAMzcIWrWIZiXYs5jnmrN/btOcRMwIPUq44Vy0vlV4+QoIG0+EvsZ51N/zMexlyMBdNQ==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/plasma-light-client/-/plasma-light-client-0.0.34.tgz",
+			"integrity": "sha512-6qS6eaOcedNTVkm3H0G9dNrML9Fx1ZiEWpE98h/qIwoktmCrp2zu9dRFPcFsLv5WGPR4Tnm2D0JPl3O4lFLJ8Q==",
 			"requires": {
-				"@cryptoeconomicslab/coder": "^0.0.27",
-				"@cryptoeconomicslab/contract": "^0.0.27",
-				"@cryptoeconomicslab/db": "^0.0.27",
-				"@cryptoeconomicslab/hash": "^0.0.27",
+				"@cryptoeconomicslab/coder": "^0.0.34",
+				"@cryptoeconomicslab/contract": "^0.0.34",
+				"@cryptoeconomicslab/db": "^0.0.34",
+				"@cryptoeconomicslab/hash": "^0.0.34",
 				"@cryptoeconomicslab/indexeddb-kvs": "^0.0.3",
-				"@cryptoeconomicslab/merkle-tree": "^0.0.27",
-				"@cryptoeconomicslab/ovm": "^0.0.27",
-				"@cryptoeconomicslab/plasma": "^0.0.27",
-				"@cryptoeconomicslab/wallet": "^0.0.27",
+				"@cryptoeconomicslab/merkle-tree": "^0.0.34",
+				"@cryptoeconomicslab/ovm": "^0.0.34",
+				"@cryptoeconomicslab/plasma": "^0.0.34",
+				"@cryptoeconomicslab/wallet": "^0.0.34",
 				"axios": "^0.19.2",
 				"event-emitter": "^0.3.5",
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/primitives": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/primitives/-/primitives-0.0.27.tgz",
-			"integrity": "sha512-y84mXmViEvjlyhYt2iZ32ATmkLIKJIaKuPoam0SDiWYylcos8lU+0o0YOQb1/HBEs5PSMQSqHwXA87YpIGQ3dg==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/primitives/-/primitives-0.0.34.tgz",
+			"integrity": "sha512-/981FV+S7Alteho5dz/V6pvPBpMqERCBUXAaJRydht+VEDd6M+s47kajlpNdJ+g4S5tKzZvZa89hjYXyPH9f7A==",
 			"requires": {
 				"jsbi": "^3.1.1",
 				"text-encoding": "^0.7.0"
 			}
 		},
 		"@cryptoeconomicslab/signature": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/signature/-/signature-0.0.27.tgz",
-			"integrity": "sha512-zc5bDmGBs+QspySKjPVQR3MyK77L8W3UUSjNboZBzCviA52Y8BXVmOqp/2ifpaQyQvJ63oeXPcGltAMI4mVylA==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/signature/-/signature-0.0.34.tgz",
+			"integrity": "sha512-WWTS3RdaMgBp/o1yQxDTLJoc4dDSP25RpFvJWx4+3/nDQ0zSyXEG2c4AueslsAb3zQZulbf78aY/2hb5i7GA4g==",
 			"requires": {
 				"bs58check": "^2.1.2",
 				"ethers": "^4.0.43",
-				"libsodium-wrappers-sumo": "^0.7.6"
-			}
-		},
-		"@cryptoeconomicslab/tezos-coder": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/tezos-coder/-/tezos-coder-0.0.6.tgz",
-			"integrity": "sha512-1ofThTOjNMzcqAvk3V9YgLV03c4A7zFzZHe/10wkzwTZ6HGnadzpX9/0+p4aU6vY9y+r7j1icoAuc7L3TKAGdw==",
-			"requires": {
-				"conseiljs": "^0.3.1",
-				"jsbi": "^3.1.1",
-				"lodash.flattendeep": "^4.4.0"
-			}
-		},
-		"@cryptoeconomicslab/tezos-contract": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/tezos-contract/-/tezos-contract-0.0.6.tgz",
-			"integrity": "sha512-jCC6arR6batb3K63q3H+00nBgPpmW8SglPLPpzd6Owu9HzIdJfMf56hAHmv5zwVSVNlhD9EqbLwJkJAk7FY1pA==",
-			"requires": {
-				"@cryptoeconomicslab/contract": "^0.0.27",
-				"@cryptoeconomicslab/db": "^0.0.27",
-				"@cryptoeconomicslab/level-kvs": "^0.0.6",
-				"@cryptoeconomicslab/ovm": "^0.0.27",
-				"@cryptoeconomicslab/tezos-coder": "^0.0.6",
-				"@cryptoeconomicslab/tezos-wallet": "^0.0.6",
-				"conseiljs": "^0.3.1",
-				"lodash.flattendeep": "^4.4.0"
-			}
-		},
-		"@cryptoeconomicslab/tezos-wallet": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/tezos-wallet/-/tezos-wallet-0.0.6.tgz",
-			"integrity": "sha512-0M/+eW9LMh4aagD7pApCbL6iKBTdq6f7kj1b6Ej/fiGYkRL3WnRFBFhjGrqf8K4k1KjLhvlgGWdMN/Dx36TPow==",
-			"requires": {
-				"@cryptoeconomicslab/signature": "^0.0.27",
-				"@cryptoeconomicslab/tezos-coder": "^0.0.6",
-				"@cryptoeconomicslab/wallet": "^0.0.27",
-				"conseiljs": "^0.3.1",
-				"lodash.flattendeep": "^4.4.0"
+				"tweetnacl": "^1.0.3"
 			}
 		},
 		"@cryptoeconomicslab/utils": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/utils/-/utils-0.0.27.tgz",
-			"integrity": "sha512-nlsQB1Iu2PGem4pHfZndi+qAK9C1fdXsyyykbCpJe9Jt9AvQJeKuTZAlwf6d92uxSxagi5WxQTFDtp7dqvqjRg==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/utils/-/utils-0.0.34.tgz",
+			"integrity": "sha512-BgofHfPFOB0L7JLygUVx/2KPQTNC5if/aP+faQteC1iaKSwq/HtsfYRQq1RDRqXgNdHnJxE+pBFP14c3FJCqbQ==",
 			"requires": {
 				"jsbi": "^3.1.1"
 			}
 		},
 		"@cryptoeconomicslab/wallet": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/wallet/-/wallet-0.0.27.tgz",
-			"integrity": "sha512-pUFz49xHsO2h+IY8mVSton9W6U5KnJd8fgcM1RTA8akKzdbJxBHPS8WXO/CxgAaOIh9l8NCc7Da4zgLfcuj4WQ==",
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/@cryptoeconomicslab/wallet/-/wallet-0.0.34.tgz",
+			"integrity": "sha512-wWyHbbkPZSHGa6p2HYXnCtecpf9/+WZ3zcfJHtubnBtygLX/iDwwX7SWgDyEL0fNCxR62KarmWL1pFVX/PpVOQ==",
 			"requires": {
 				"jsbi": "^3.1.1"
 			}
@@ -902,11 +865,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
-		},
 		"loglevel": {
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
@@ -1325,9 +1283,9 @@
 			"integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -1336,6 +1294,11 @@
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"tweetnacl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
 		},
 		"type": {
 			"version": "1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,11 +32,11 @@
     "clean": "rm -rf lib docs"
   },
   "dependencies": {
-    "@cryptoeconomicslab/context": "^0.0.27",
+    "@cryptoeconomicslab/context": "0.0.34",
     "@cryptoeconomicslab/level-kvs": "^0.0.6",
-    "@cryptoeconomicslab/ovm": "^0.0.27",
-    "@cryptoeconomicslab/plasma-light-client": "^0.0.27",
-    "@cryptoeconomicslab/primitives": "^0.0.27",
+    "@cryptoeconomicslab/ovm": "0.0.34",
+    "@cryptoeconomicslab/plasma-light-client": "0.0.34",
+    "@cryptoeconomicslab/primitives": "0.0.34",
     "@cryptoeconomicslab/tezos-coder": "^0.0.8",
     "@cryptoeconomicslab/tezos-contract": "^0.0.8",
     "@cryptoeconomicslab/tezos-wallet": "^0.0.8",

--- a/packages/coder/package.json
+++ b/packages/coder/package.json
@@ -61,5 +61,5 @@
     "jsbi": "^3.1.1",
     "lodash.flattendeep": "^4.4.0"
   },
-  "gitHead": "84db76a7e563b6be70794ff270af86e670eb3e70"
+  "gitHead": "09fb78d66ccfcd48656b8081e2296b7156594d97"
 }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -67,5 +67,5 @@
   "peerDependencies": {
     "@cryptoeconomicslab/primitives": "^0.0.27"
   },
-  "gitHead": "84db76a7e563b6be70794ff270af86e670eb3e70"
+  "gitHead": "09fb78d66ccfcd48656b8081e2296b7156594d97"
 }

--- a/packages/plasma-aggregator/package.json
+++ b/packages/plasma-aggregator/package.json
@@ -67,5 +67,5 @@
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   },
-  "gitHead": "84db76a7e563b6be70794ff270af86e670eb3e70"
+  "gitHead": "09fb78d66ccfcd48656b8081e2296b7156594d97"
 }

--- a/packages/wallet/package-lock.json
+++ b/packages/wallet/package-lock.json
@@ -766,6 +766,11 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
+		"node-gyp-build": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz",
+			"integrity": "sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ=="
+		},
 		"node-hid": {
 			"version": "0.7.9",
 			"resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.7.9.tgz",
@@ -1004,6 +1009,15 @@
 				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
+			}
+		},
+		"sodium-native": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.0.0.tgz",
+			"integrity": "sha512-euffb+nZSuxDsnURTmFa3sTg9cTj3pss8JwRiPe8FvtdT1CrwUKtFmuwbnJ+RNSCf+NBygIq3qPTiYqzEjeX8Q==",
+			"requires": {
+				"ini": "^1.3.5",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"string-width": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -64,5 +64,5 @@
   "peerDependencies": {
     "@cryptoeconomicslab/primitives": "^0.0.27"
   },
-  "gitHead": "84db76a7e563b6be70794ff270af86e670eb3e70"
+  "gitHead": "09fb78d66ccfcd48656b8081e2296b7156594d97"
 }

--- a/packages/wallet/src/TzWalletFactory.ts
+++ b/packages/wallet/src/TzWalletFactory.ts
@@ -1,8 +1,16 @@
 import { Wallet, WalletFactory } from '@cryptoeconomicslab/wallet'
 import { TzWallet } from './TzWallet'
-import { ConseilServerInfo, TezosWalletUtil } from 'conseiljs'
+import {
+  ConseilServerInfo,
+  TezosMessageUtils,
+  StoreType,
+  KeyStore
+} from 'conseiljs'
+import tweetnacl from 'tweetnacl'
 
 export class TzWalletFactory implements WalletFactory {
+  static PRIVATE_KEY_LENGTH = 32
+
   // Default ServerInfo won't connect to network
   conseilServerInfo: ConseilServerInfo = {
     url: '',
@@ -20,8 +28,24 @@ export class TzWalletFactory implements WalletFactory {
   }
 
   async fromPrivateKey(privateKey: string): Promise<Wallet> {
+    const secretKey = TezosMessageUtils.writeKeyWithHint(privateKey, 'edsk')
+    const keys = tweetnacl.sign.keyPair.fromSeed(
+      secretKey.slice(0, TzWalletFactory.PRIVATE_KEY_LENGTH)
+    )
+    const publicKey = TezosMessageUtils.readKeyWithHint(keys.publicKey, 'edpk')
+    const publicKeyHash = TezosMessageUtils.computeKeyHash(
+      Buffer.from(keys.publicKey),
+      'tz1'
+    )
+    const keyStore: KeyStore = {
+      publicKey: publicKey,
+      privateKey: privateKey,
+      publicKeyHash: publicKeyHash,
+      seed: '',
+      storeType: StoreType.Mnemonic
+    }
     return new TzWallet(
-      await TezosWalletUtil.restoreIdentityWithSecretKey(privateKey),
+      keyStore,
       this.tezosNodeEndpoint,
       this.conseilServerInfo
     )


### PR DESCRIPTION
don't use CryptoUtils.restoreIdentityWithSecretKey()
Because the method uses `libsodium-wrappers-sumo`